### PR TITLE
Update comment to reflect registry name

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -1,5 +1,5 @@
 # ==========================================
-# BOWER: Server
+# BOWER: Registry
 # ==========================================
 # Copyright 2012 Twitter, Inc
 # Licensed under The MIT License


### PR DESCRIPTION
It seems to be the case that the former name for bower registry was bower server.
