### PR TITLE
Allowing for ssh URI as well (prevents repository not found for private repos)

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -36,7 +36,7 @@ class Package < Sequel::Model
 
   def validate
     super
-    errors.add(:url, 'is not correct format') if url !~ /^git:\/\//
+    errors.add(:url, 'is not correct format') if url !~ /^(git|ssh):\/\//
   end
 
   def as_json


### PR DESCRIPTION
I might have been doing something stupid, but we were attempting to create a private registry and the git URLs formatted in the following way were not working:

```
git://github.com/[organization]/[name]
```

Formatting this way did work, but was failing validation:

```
ssh://github.com/[organization]/[name]
```
