### PR TITLE
First cut of the unregister function

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -12,3 +12,4 @@ app.get('/packages', routes.packages.list);
 app.get('/packages/:name', routes.packages.fetch);
 app.get('/packages/search/:name', routes.packages.search);
 app.post('/packages', routes.packages.create);
+app.del('/packages/:name', routes.packages.remove);

--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -2,7 +2,77 @@
 
 var serverStatus = require('../status');
 var database = require('../database');
+var url = require('url');
+var path = require('path');
+var GithubClient = require('github');
 
+var isowner = function (packageName, token, callback) {
+    if (!token) {
+        return callback(null, false);
+    }
+
+    var githubClient = new GithubClient({
+        version: '3.0.0'
+    });
+    githubClient.authenticate({
+        type: "oauth",
+        token: token
+    });
+
+    database.getPackage(packageName, function (error, result) {
+        if (error) {
+            return callback(error);
+        }
+        if (result.rows.length === 0) {
+            return callback(new Error('Not found'));
+        }
+
+        var pkg = result.rows[0];
+        var urlParts = url.parse(pkg.url);
+        var pathParts = urlParts.pathname.split('/');
+
+        if (urlParts.hostname !== 'github.com') {
+            return callback(null, false); // Not a github hosted package
+        }
+
+        if (pathParts.length !== 3 || pathParts[0] !== '') {
+            return callback(null, false); // Path is garbage
+        }
+
+        var owner = pathParts[1];
+        var repo = path.basename(pathParts[2], '.git');
+
+        githubClient.user.get({}, function (error, user) {
+            if (error) {
+                return callback(error);
+            }
+            githubClient.repos.getCollaborator({
+                user: owner,
+                repo: repo,
+                collabuser: user.login
+            }, callback);
+        });
+    });
+};
+
+exports.remove = function (request, response) {
+    isowner(request.params.name, request.query.access_token, function (error, result) {
+        if (error) {
+            return response.send(500, error.message);
+        }
+        if (!result) {
+            return response.send(403);
+        }
+
+        database.deletePackage(request.params.name, function (error) {
+            if (error) {
+                return response.send(500, error.message);
+            }
+
+            return response.send(204);
+        });
+    });
+};
 
 exports.list = function (request, response) {
     serverStatus.allPackages++;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "express": "~3.4.8",
+    "github": "~0.1.15",
     "pg": "~2.11.1"
   }
 }


### PR DESCRIPTION
This adds a new feature to the server allowing people to unregister packages.

You send an HTTP `DELETE` request to `https://{server url}/packages/{package name}?access_token={token}` where `token` is an OAuth token issued by GitHub.

The request will succeed if and only if you have commit access to the github repo that is registered for the package.

Actually generating the tokens for a user will be handled in an update to the client.
