### PR TITLE
Let registry admins be "owners" of any package

### DIFF
--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -50,7 +50,15 @@ var isowner = function (packageName, token, callback) {
                 user: owner,
                 repo: repo,
                 collabuser: user.login
-            }, callback);
+            }, function (error, result) {
+                if (error) {
+                    return githubClient.orgs.getTeamMember({
+                        id: 762801, // Hard-coded - this is the Bower registry editors team
+                        user: user.login
+                    }, callback);
+                }
+                return callback(error, result);
+            });
         });
     });
 };


### PR DESCRIPTION
A registry admin being anyone who is a member of a particular GitHub group, https://github.com/orgs/bower/teams/registry-editors
