### PR TITLE
Ensure environment variables are set before starting node server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ function deletePkg(name){ d.deletePackage(name, function (err, res) { console.lo
 deletePkg("package-name") // and repeat as neccessary
 ```
 
+## Defaults
+
+If the `PORT` and/or `DATABASE_URL` environment variables are not set, the registry will use the following defaults:
+
+`PORT=3000` and/or `DATABASE_URL=0.0.0.0`.
+
+In order to change either variable, set them in your environment: (i.e. linux)
+
+```export PORT=[port]```
+
+```export DATABASE_URL=[url]```
+
 ## License
 
 Copyright 2014 Twitter, Inc.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ var express = require('express');
 
 var app = express();
 
+if (typeof process.env.PORT === 'undefined') {
+    process.env.PORT = 3000;
+}
+
+if (typeof process.env.DATABASE_URL === 'undefined') {
+    process.env.DATABASE_URL = '0.0.0.0';
+}
+
 app.configure(function () {
     app.use(express.logger());
     app.use(express.compress());
@@ -17,4 +25,7 @@ app.listen(process.env.PORT);
 exports.app = app;
 require('./lib/routes');
 
+console.log('This app is using port ' + process.env.PORT + ' and the database url is ' + process.env.DATABASE_URL + '.');
+
+//Tests look for this string to make sure the server is loaded
 console.log('ready.');

--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -69,7 +69,7 @@ function isOwner (packageName, token, callback) {
             }));
         });
     });
-};
+}
 
 exports.remove = function (request, response) {
     /* jshint camelcase: false */


### PR DESCRIPTION
If a port is not instantiated as an environment variable it passes 'undefined' to Express.  Express does not handle a undefined port and the result is ip:false, rather than ip:port or ip:0.  Checks should be added to keep the server from running unless the environment variables are created.
