### PR TITLE
Allow anybody to remove a stale package

### DIFF
--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -51,22 +51,34 @@ function isOwner (packageName, token, callback) {
             };
         }
 
-        githubClient.user.get({}, function (error, user) {
+        githubClient.repos.get({
+            user: owner,
+            repo: repo
+        }, function (error) {
             if (error) {
+                // If the repository doesn't exist, anybody can remove the package.
+                if (error.code === 404) {
+                    return callback(null, true);
+                }
                 return callback({ status: 500, message: 'GitHub.com error' });
             }
-            githubClient.repos.getCollaborator({
-                user: owner,
-                repo: repo,
-                collabuser: user.login
-            }, ghCheck(function () {
-                githubClient.orgs.getTeamMember({
-                    id: config.registryEditorsID,
-                    user: user.login
+            githubClient.user.get({}, function (error, user) {
+                if (error) {
+                    return callback({ status: 500, message: 'GitHub.com error' });
+                }
+                githubClient.repos.getCollaborator({
+                    user: owner,
+                    repo: repo,
+                    collabuser: user.login
                 }, ghCheck(function () {
-                    callback(null, false);
+                    githubClient.orgs.getTeamMember({
+                        id: config.registryEditorsID,
+                        user: user.login
+                    }, ghCheck(function () {
+                        callback(null, false);
+                    }));
                 }));
-            }));
+            });
         });
     });
 };


### PR DESCRIPTION
If the GitHub repo referenced by a Bower package is no longer accessible, anybody should be allowed to remove that Bower package.

This should resolve a number of the errors people are encountering on bower/bower#120. It also incidentally fixes #69. 