### PR TITLE
Normalize GitHub urls

### DIFF
--- a/lib/normalizeURL.js
+++ b/lib/normalizeURL.js
@@ -1,0 +1,17 @@
+module.exports = function(url) {
+  url = url || '';
+
+  var githubURLRegex = /^(?:(?:git:\/\/|https?:\/\/(?:(?:\w+\:)?\w+@)?)|git@)(?:www\.)?github.com(?:\:|\/|:\/)([^\/]+)\/(.*?)(?:\.git)?(?:\/)?$/;
+  var matchedURL = url.match(githubURLRegex);
+  var username;
+  var repo;
+
+  if (matchedURL) {
+    username = matchedURL[1];
+    repo = matchedURL[2];
+
+    url = 'git://github.com/' + username + '/' + repo + '.git';
+  }
+
+  return url;
+};

--- a/lib/routes/packages.js
+++ b/lib/routes/packages.js
@@ -5,6 +5,7 @@ var database = require('../database');
 var config = require('../config');
 var isValidName = require('../validName');
 var validateURL = require('../validURL');
+var normalizeURL = require('../normalizeURL');
 var url = require('url');
 var path = require('path');
 var GithubClient = require('github');
@@ -112,7 +113,7 @@ exports.list = function (request, response) {
 
 exports.create = function (request, response) {
     var name = request.body.name;
-    var url = request.body.url;
+    var url = normalizeURL(request.body.url);
 
     serverStatus.createPackage++;
 

--- a/test/normalizeGithubURLs.js
+++ b/test/normalizeGithubURLs.js
@@ -1,0 +1,57 @@
+var assert = require('chai').assert;
+var normalizeURL = require('../lib/normalizeURL');
+var normalizedURL = 'git://github.com/bower/Bower.git';
+
+
+describe('package names', function(){
+
+    it('should support git urls with no extension', function () {
+        return assert.equal(normalizeURL('git://github.com/bower/Bower'), normalizedURL);
+    });
+
+    it('should support git urls with extensions', function () {
+        return assert.equal(normalizeURL('git://github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support urls with www subdomain', function () {
+        return assert.equal(normalizeURL('git://www.github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support http urls', function () {
+        return assert.equal(normalizeURL('http://github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support https urls', function () {
+        return assert.equal(normalizeURL('https://github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support url with a trailing slash and no extension', function () {
+        return assert.equal(normalizeURL('https://github.com/bower/Bower/'), normalizedURL);
+    });
+
+    it('should support url with a trailing slash and an extension', function () {
+        return assert.equal(normalizeURL('https://github.com/bower/Bower.git/'), normalizedURL);
+    });
+
+    it('should support http(s) urls with basic-auth username', function () {
+        return assert.equal(normalizeURL('https://bower@github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support http(s) urls with basic-auth username and password', function () {
+        return assert.equal(normalizeURL('https://bower:bower@github.com/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support ssh urls', function () {
+        return assert.equal(normalizeURL('git@github.com:bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support ssh urls with a preceeding slash', function () {
+        return assert.equal(normalizeURL('git@github.com:/bower/Bower.git'), normalizedURL);
+    });
+
+    it('should support urls with dots in the name and an extension', function () {
+        return assert.equal(normalizeURL('https://github.com/bower/Bower.js.git'), 'git://github.com/bower/Bower.js.git');
+    });
+
+
+});


### PR DESCRIPTION
fixes #7

builds on top of #78

ran this though all registered packages and it covers all of them except the following

``` JSON
{
    "name": "ember-build-validations",
    "url": "git://github.com/dockyard/ember-builds/tree/master/validations"
},{
    "name": "grid-generator#1.0.1",
    "url": "git://github.com/martinmaricak/Grid-Generator/releases/tag/1.0.1"
},{
    "name": "kojs",
    "url": "git://github.com/SteveSanderson/knockout/blob/master/build/output/knockout-latest.js"
},{
    "name": "linq",
    "url": "git://github.com/mihaifm/linq/blob/master/linq.js"
},{
    "name": "RangeSlider",
    "url": "git://ghusse.github.com/jQRangeSlider"
},{
    "name": "squeezr",
    "url": "git://github.com/jkphl/squeezr/tree/master/squeezr"
}
```

All of which are invalid and can't be downloaded anyway.
