### PR TITLE
add search-by-url

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -52,5 +52,5 @@ exports.hit = function (name) {
 };
 
 exports.searchPackages = function (term, callback) {
-    query('SELECT name, url FROM packages WHERE name ILIKE $1 ORDER BY hits DESC', ['%' + term + '%'], callback);
+    query('SELECT name, url FROM packages WHERE name ILIKE $1 OR url ILIKE $1 ORDER BY hits DESC', ['%' + term + '%'], callback);
 };


### PR DESCRIPTION
this implementation is pretty naïve. Since we can't really validate urls or names to search just one (since we fuzzy match), it just searches both fields and returns the results. Using UNION to join two seperate searches prevents ORDER BY from working properly, and UNION ALL would result in the possibility of a bunch of duplicates. As a result, neither name or url are weighted.
