### PR TITLE
Accept ssh scheme for package registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 node_modules/
-*.iml
-.idea/
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/
+*.iml
+.idea/
 npm-debug.log

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -53,7 +53,7 @@ Package.prototype.update = function (data) {
         }
     }
 
-    if (!/^(https?|git):\/\//.test(data.url)) {
+    if (!/^(https?|ssh?|git):\/\//.test(data.url)) {
         if (data.url !== '/archives/' + data.name) {
             throw new Error('Unsupported URL type "' + data.url + '"');
         }

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -53,7 +53,7 @@ Package.prototype.update = function (data) {
         }
     }
 
-    if (!/^(https?|ssh?|git):\/\//.test(data.url)) {
+    if (!/^(https?|git):\/\//.test(data.url)) {
         if (data.url !== '/archives/' + data.name) {
             throw new Error('Unsupported URL type "' + data.url + '"');
         }


### PR DESCRIPTION
This simple fix allowed us to use registry with private git repo that is not supporting https or git protocol (we insist on ssh keys only)

It would be great if we could include this into node_rewrite branch, and eventually even in stable

it works really easy, you just register url with ssh://git@your-private-domain.com/repo.git