### PR TITLE
Fix undefined value in error console output

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -126,7 +126,7 @@ exports.createDatabase = function () {
 
     return adminQuery('CREATE DATABASE ' + connectionParams.database).then(
         null,
-        function (error) { console.error(error.messagePrimary); }
+        function (error) { console.error(error.message); }
     );
 };
 
@@ -141,6 +141,6 @@ exports.dropDatabase = function () {
 
     return adminQuery('DROP DATABASE ' + connectionParams.database).then(
         null,
-        function (error) { console.error(error.messagePrimary); }
+        function (error) { console.error(error.message); }
     );
 };


### PR DESCRIPTION
The used `error.messagePrimary` is always `undefined`, actually nowhere to be seen in Bluebird.js' [error module](https://github.com/petkaantonov/bluebird/blob/master/src/errors.js).

This fixes it.