### PR TITLE
Small refactor for the routes file

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ app.listen(config.get('port'));
 
 exports.app = app;
 
-require('./lib/routes');
+require('./lib/routes')(app);
 
 app.use(errorHandler({ log: true }));
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var app = module.parent.exports.app;
+module.exports = function(app) {
+    var routes = {
+        root: require('./root'),
+        packages: require('./packages')
+    };
 
-var routes = {
-    root: require('./root'),
-    packages: require('./packages')
+    app.get('/', function(req, res) {
+        res.redirect(302, 'http://bower.io/search/');
+    });
+
+    app.get('/status', routes.root.status);
+
+    app.get('/packages', routes.packages.list);
+    app.get('/packages/:name', routes.packages.fetch);
+    app.get('/packages/search/', routes.packages.search);
+    app.get('/packages/search/:name', routes.packages.search);
+    app.post('/packages', routes.packages.create);
+    app.delete('/packages/:name', routes.packages.remove);
 };
-
-app.get('/', function(req, res) {
-  res.redirect(302, 'http://bower.io/search/');
-});
-
-app.get('/status', routes.root.status);
-
-app.get('/packages', routes.packages.list);
-app.get('/packages/:name', routes.packages.fetch);
-app.get('/packages/search/', routes.packages.search);
-app.get('/packages/search/:name', routes.packages.search);
-app.post('/packages', routes.packages.create);
-app.delete('/packages/:name', routes.packages.remove);


### PR DESCRIPTION
Hi there,
Just wanted to suggest this way of handling the excess to the express app from the routes file.
I made the routes file expose a function that accepts the express app.
Therefore we can avoid this line:
```js
var app = module.parent.exports.app;
```