### PR TITLE
Add compiler for io.js on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ node_js:
   - '0.10'
 services:
   - memcached
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
Fix build error

ref: https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements